### PR TITLE
fixes test for question 5's #reverse_array

### DIFF
--- a/spec/collections_practice_spec.rb
+++ b/spec/collections_practice_spec.rb
@@ -32,8 +32,8 @@ describe 'collections practice' do
 
   # Question 5
   describe '#reverse_array' do
-    it 'reverse the order of an array' do
-      expect(reverse_array(["blake", "ashley", "scott"])).to eq(["scott", "ashley", "blake"])
+    it 'reverse the order of an array of integers' do
+      expect(reverse_array([12, 4, 35])).to eq([35, 4, 12])
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/learn-co-curriculum/collections_practice/issues/39

Reconciles the test for `#reverse_array` with its description in the README by making the tested array an array of integers instead of strings.