### PR TITLE
adds "s" to array items w/ same value as array[1]

### DIFF
--- a/collections_practice.rb
+++ b/collections_practice.rb
@@ -62,11 +62,11 @@ def sum_array(array)
 end
 
 def add_s(array)
-  array.collect do |word|
-    if array[1] == word
-      word
+  array.map.with_index do |item, i|
+    if i != 1
+      item << "s"
     else
-      word + "s"
+      item
     end
   end
 end


### PR DESCRIPTION
In `add_s(array)`, the given solution would ignore all subsequent items in array that equal the value at `array[1]` and leave them unmodified.

According to test instructions, only the second value in the array does not have an "s" appended to it. With these instructions one would expect an input of `["hand","feet", "knee", "table", "feet", "feet"]` to result in `["hands","feet", "knees", "tables", "feets", "feets"]`.

The old solution outputs `["hands", "feet", "knees", "tables", "feet", "feet"]`.

Using `map.with_index` ensures only one match.